### PR TITLE
[STEP1] 연락처 관리 프로그램(UI Ver) - Sunny, Is

### DIFF
--- a/ios-contact-manager/ContactManagerUI/AppDelegate.swift
+++ b/ios-contact-manager/ContactManagerUI/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  ContactManagerUI
+//
+//  Created by 송선진 on 2023/01/30.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/ios-contact-manager/ContactManagerUI/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios-contact-manager/ContactManagerUI/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios-contact-manager/ContactManagerUI/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios-contact-manager/ContactManagerUI/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios-contact-manager/ContactManagerUI/Assets.xcassets/Contents.json
+++ b/ios-contact-manager/ContactManagerUI/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios-contact-manager/ContactManagerUI/Base.lproj/LaunchScreen.storyboard
+++ b/ios-contact-manager/ContactManagerUI/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/ios-contact-manager/ContactManagerUI/Base.lproj/Main.storyboard
+++ b/ios-contact-manager/ContactManagerUI/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/ios-contact-manager/ContactManagerUI/Info.plist
+++ b/ios-contact-manager/ContactManagerUI/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/ios-contact-manager/ContactManagerUI/SceneDelegate.swift
+++ b/ios-contact-manager/ContactManagerUI/SceneDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  SceneDelegate.swift
+//  ContactManagerUI
+//
+//  Created by 송선진 on 2023/01/30.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/ios-contact-manager/ContactManagerUI/ViewController.swift
+++ b/ios-contact-manager/ContactManagerUI/ViewController.swift
@@ -1,0 +1,19 @@
+//
+//  ViewController.swift
+//  ContactManagerUI
+//
+//  Created by 송선진 on 2023/01/30.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+    }
+
+
+}
+

--- a/ios-contact-manager/ios-contact-manager.xcodeproj/project.pbxproj
+++ b/ios-contact-manager/ios-contact-manager.xcodeproj/project.pbxproj
@@ -14,6 +14,19 @@
 		4FCF500A2953F7B200CA262F /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCF50092953F7B200CA262F /* Error.swift */; };
 		4FCF500C2954157F00CA262F /* ContactManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCF500B2954157F00CA262F /* ContactManager.swift */; };
 		4FCF500E2955668900CA262F /* Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCF500D2955668900CA262F /* Extension.swift */; };
+		4FEEF66229879DE000FF6A89 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEEF66129879DE000FF6A89 /* AppDelegate.swift */; };
+		4FEEF66429879DE000FF6A89 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEEF66329879DE000FF6A89 /* SceneDelegate.swift */; };
+		4FEEF66629879DE000FF6A89 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEEF66529879DE000FF6A89 /* ViewController.swift */; };
+		4FEEF66929879DE000FF6A89 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4FEEF66729879DE000FF6A89 /* Main.storyboard */; };
+		4FEEF66B29879DE200FF6A89 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4FEEF66A29879DE200FF6A89 /* Assets.xcassets */; };
+		4FEEF66E29879DE200FF6A89 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4FEEF66C29879DE200FF6A89 /* LaunchScreen.storyboard */; };
+		4FEEF67329879E0300FF6A89 /* Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCF500D2955668900CA262F /* Extension.swift */; };
+		4FEEF67429879E1900FF6A89 /* StringLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F965532952ED4200ACCA0C /* StringLiteral.swift */; };
+		4FEEF67529879E1D00FF6A89 /* IOManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCF50072953F79200CA262F /* IOManager.swift */; };
+		4FEEF67629879E2200FF6A89 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCF50092953F7B200CA262F /* Error.swift */; };
+		4FEEF67729879E2500FF6A89 /* ContactManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCF500B2954157F00CA262F /* ContactManager.swift */; };
+		4FEEF67829879E2800FF6A89 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4062671D2954226900A2CBE4 /* UserInfo.swift */; };
+		4FEEF67929879E2B00FF6A89 /* Phonebook.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D47EA1295C8D1600063E40 /* Phonebook.swift */; };
 		B2D47EA2295C8D1600063E40 /* Phonebook.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D47EA1295C8D1600063E40 /* Phonebook.swift */; };
 /* End PBXBuildFile section */
 
@@ -38,11 +51,26 @@
 		4FCF50092953F7B200CA262F /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		4FCF500B2954157F00CA262F /* ContactManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactManager.swift; sourceTree = "<group>"; };
 		4FCF500D2955668900CA262F /* Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extension.swift; sourceTree = "<group>"; };
+		4FEEF65F29879DE000FF6A89 /* ContactManagerUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ContactManagerUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		4FEEF66129879DE000FF6A89 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		4FEEF66329879DE000FF6A89 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		4FEEF66529879DE000FF6A89 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		4FEEF66829879DE000FF6A89 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		4FEEF66A29879DE200FF6A89 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		4FEEF66D29879DE200FF6A89 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		4FEEF66F29879DE200FF6A89 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B2D47EA1295C8D1600063E40 /* Phonebook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Phonebook.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		4FCF4FF62952A4AE00CA262F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4FEEF65C29879DE000FF6A89 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -56,6 +84,7 @@
 			isa = PBXGroup;
 			children = (
 				4FCF4FFB2952A4AE00CA262F /* ios-contact-manager */,
+				4FEEF66029879DE000FF6A89 /* ContactManagerUI */,
 				4FCF4FFA2952A4AE00CA262F /* Products */,
 			);
 			sourceTree = "<group>";
@@ -64,6 +93,7 @@
 			isa = PBXGroup;
 			children = (
 				4FCF4FF92952A4AE00CA262F /* ios-contact-manager */,
+				4FEEF65F29879DE000FF6A89 /* ContactManagerUI.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -81,6 +111,20 @@
 				B2D47EA1295C8D1600063E40 /* Phonebook.swift */,
 			);
 			path = "ios-contact-manager";
+			sourceTree = "<group>";
+		};
+		4FEEF66029879DE000FF6A89 /* ContactManagerUI */ = {
+			isa = PBXGroup;
+			children = (
+				4FEEF66129879DE000FF6A89 /* AppDelegate.swift */,
+				4FEEF66329879DE000FF6A89 /* SceneDelegate.swift */,
+				4FEEF66529879DE000FF6A89 /* ViewController.swift */,
+				4FEEF66729879DE000FF6A89 /* Main.storyboard */,
+				4FEEF66A29879DE200FF6A89 /* Assets.xcassets */,
+				4FEEF66C29879DE200FF6A89 /* LaunchScreen.storyboard */,
+				4FEEF66F29879DE200FF6A89 /* Info.plist */,
+			);
+			path = ContactManagerUI;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -103,6 +147,23 @@
 			productReference = 4FCF4FF92952A4AE00CA262F /* ios-contact-manager */;
 			productType = "com.apple.product-type.tool";
 		};
+		4FEEF65E29879DE000FF6A89 /* ContactManagerUI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4FEEF67229879DE200FF6A89 /* Build configuration list for PBXNativeTarget "ContactManagerUI" */;
+			buildPhases = (
+				4FEEF65B29879DE000FF6A89 /* Sources */,
+				4FEEF65C29879DE000FF6A89 /* Frameworks */,
+				4FEEF65D29879DE000FF6A89 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ContactManagerUI;
+			productName = ContactManagerUI;
+			productReference = 4FEEF65F29879DE000FF6A89 /* ContactManagerUI.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -114,6 +175,9 @@
 				LastUpgradeCheck = 1420;
 				TargetAttributes = {
 					4FCF4FF82952A4AE00CA262F = {
+						CreatedOnToolsVersion = 14.2;
+					};
+					4FEEF65E29879DE000FF6A89 = {
 						CreatedOnToolsVersion = 14.2;
 					};
 				};
@@ -132,9 +196,23 @@
 			projectRoot = "";
 			targets = (
 				4FCF4FF82952A4AE00CA262F /* ios-contact-manager */,
+				4FEEF65E29879DE000FF6A89 /* ContactManagerUI */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		4FEEF65D29879DE000FF6A89 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4FEEF66E29879DE200FF6A89 /* LaunchScreen.storyboard in Resources */,
+				4FEEF66B29879DE200FF6A89 /* Assets.xcassets in Resources */,
+				4FEEF66929879DE000FF6A89 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		4FCF4FF52952A4AE00CA262F /* Sources */ = {
@@ -152,7 +230,43 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4FEEF65B29879DE000FF6A89 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4FEEF66629879DE000FF6A89 /* ViewController.swift in Sources */,
+				4FEEF67529879E1D00FF6A89 /* IOManager.swift in Sources */,
+				4FEEF66229879DE000FF6A89 /* AppDelegate.swift in Sources */,
+				4FEEF66429879DE000FF6A89 /* SceneDelegate.swift in Sources */,
+				4FEEF67329879E0300FF6A89 /* Extension.swift in Sources */,
+				4FEEF67929879E2B00FF6A89 /* Phonebook.swift in Sources */,
+				4FEEF67629879E2200FF6A89 /* Error.swift in Sources */,
+				4FEEF67729879E2500FF6A89 /* ContactManager.swift in Sources */,
+				4FEEF67829879E2800FF6A89 /* UserInfo.swift in Sources */,
+				4FEEF67429879E1900FF6A89 /* StringLiteral.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		4FEEF66729879DE000FF6A89 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				4FEEF66829879DE000FF6A89 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		4FEEF66C29879DE200FF6A89 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				4FEEF66D29879DE200FF6A89 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		4FCF4FFE2952A4AE00CA262F /* Debug */ = {
@@ -292,6 +406,67 @@
 			};
 			name = Release;
 		};
+		4FEEF67029879DE200FF6A89 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = F2W258F5P6;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ContactManagerUI/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sunny.ContactManagerUI;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		4FEEF67129879DE200FF6A89 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = F2W258F5P6;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ContactManagerUI/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.sunny.ContactManagerUI;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -309,6 +484,15 @@
 			buildConfigurations = (
 				4FCF50012952A4AE00CA262F /* Debug */,
 				4FCF50022952A4AE00CA262F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4FEEF67229879DE200FF6A89 /* Build configuration list for PBXNativeTarget "ContactManagerUI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4FEEF67029879DE200FF6A89 /* Debug */,
+				4FEEF67129879DE200FF6A89 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
안녕하세요 웨더!(@SungPyo)😃 이번 연락처 관리 프로그램(UI Ver)의 Sunny, Is입니다! 이번 Step1은 다른 프로젝트와 다르게 요구사항이 매우 매우 적은 편이에요. 요구사항이 심플하기 때문에 여기에 대한 질문보단, 이번 스텝의 핵심 경험에 대해 공부한 내용을 PR에 적어보았어요. 다음 Step부턴 모르는 부분들, 궁금한 내용을 잘 정리하여 질문하도록 할게요😁


## 요구 사항 정리
- [x] STEP 1 - iOS App Target 추가
  - 첫 주차의 연락처 관리 프로그램의 Xcode 프로젝트를 기반으로 시작합니다

- [x] 기존의 연락처 관리 프로그램 프로젝트에 UIKit App Target을 추가합니다
    - Target 이름 : ContactManagerUI
    - Storyboard를 사용하며, Swift 언어를 사용합니다
- [x] ContactManager 타깃의 주요 파일을 ContactManagerUI의 타깃 멤버십 파일로 추가합니다
    - main.swift 제외


## 이번 스텝 수행 중 핵심 경험
- [x] Xcode의 Target 개념 이해
- [x] Xcode의 새로운 Target 생성
- [x] Target Membership 개념 이해

</br>

## Xcode Target
**Target이란?**
: build를 진행할 Product를 지정하는 역할

- 하나의 Target은 하나의 product 를 생성한다.
- 하나의 Project는 여러개의 Target을 가질 수 있다.
- target의 예시 : app, framework, app extension, unit test 등

**Targets 간의 Dependencies**

- Dependencies는 Xcode에게 target을 빌드하는 순서를 알려주는 역할을 한다.
    - Xcode는 가능하면 병렬로 빌드하지만, dependencies 순서에 따라 순차적으로 빌드하기도 한다.
- 만약 A target을 빌드하는데 B target의 output이 필요하다면 A target은 B target에 dependencies를 갖는다.
- Scheme’s Find implicit Dependencies가 활성화 된 경우, Xcode는  A target과 B target 간 implicit dependencies를 자동으로 생성한다.
    - Scheme’s Find implicit Dependencies가 활성화 된 경우, dependencies를 자동으로 추가할 수 있지만 Xcode가 모든 target 간 dependencies를 찾는 건 불가능하다.
    - 따라서 Xcode가 찾지 못한 target dependencies는 수동으로 추가해야 오류가 나지 않는다. (= explicit dependencies)
- 하나의 target만이 active target이 될 수 있고, Scheme가 active target을 지정한다.

</br>
</br>

## Target Membership
|![Target의 Compile Sources](https://user-images.githubusercontent.com/107124308/215670046-b785b228-082d-4b2a-85c0-5407d0d5f98b.png)|
| :--------: |
| ContactManager.swift의 File Inspector Navigation |
- Xcode 내에서 하나의 파일마다 File Inspector에서 해당 파일의 Target Membership을 설정할 수 있다.
    - ContactManager.swift는 첫 번째 타겟인 ios-contact-manager와 두 번째 타겟인 ContactManagerUI가 build될 때 complie되는 소스 코드 파일이다.
- Target Membership 설정 창에는 현재 프로젝트 내의 Target들이 있다.
    - Target Membership에 현재 프로젝트 내의 타겟인 ios-contact-manager와 ContactManagerUI를 확인할 수 있다.
- Project 정보의 특정 `Target > Build Phases > Compile Sources` 섹션에서 해당 Target Membership에 체크한 소스 파일들을 확인할 수 있다.
    |![Target의 Compile Sources](https://user-images.githubusercontent.com/107124308/215669446-265efba4-4ed1-47da-afcc-4349af5f61ef.png)|
    | :--------: |
    | ContactManagerUI를 빌드할 때 위의 소스 코드들이 Complie된다. |
- Target을 빌드할 때 함께 complie될 소스 코드를 설정하는 것이 Target Membership을 설정하는 것이다!
